### PR TITLE
Add EKS limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ Now that AWS [is charging per IPv4 address](https://aws.amazon.com/blogs/aws/new
 | Systems Manager | The SSM Agent requires IPv4 access to Systems Manager endpoints in order to function |
 | Kinesis/SQS | Examples of possible high volume AWS services, not supporting IPv6.  Requiring you to make the trade of between paying $3.50 a month for every ec2 instance using it, or spawning a VPC endpoint at 10.5$ a month for every AZ and 0.01$ per GB.  And do not forget to update all your code/config to use these new endpoints. |
 | App Runner | No option to select IPv6.  Defaults to IPv4. |
-
+| Amazon EKS | Security groups for Pods can't be used with clusters configured for the IPv6 family that contain Amazon EC2 nodes. |


### PR DESCRIPTION
Currently if you are using an EKS cluster configured for IPv6 with EC2 nodes, you are not able to use the Security Groups for Pods feature. This is a pretty big limitation because you then have to rely on security groups for individual nodes and can not restrict traffic between pods that are on mixed purposes nodes.


source: https://docs.aws.amazon.com/eks/latest/userguide/security-groups-for-pods.html